### PR TITLE
Add eligible portfolio-marked repositories

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -27,6 +27,37 @@
         "BI",
         "DAX"
       ]
+    },
+    {
+      "id": "invoice-ocr-reader-portfolio",
+      "project_title": "invoice-ocr-reader-portfolio",
+      "short_description": "Command-line OCR tool for extracting structured invoice data from PDF invoices, supporting Hebrew and English text, validation, and export to JSON, CSV, and Excel.",
+      "category": "Tool",
+      "technologies_used": [
+        "Python",
+        "Tesseract OCR",
+        "pdf2image",
+        "Pillow",
+        "pandas",
+        "openpyxl",
+        "pytest"
+      ],
+      "problem_description": "Invoice data is often locked inside PDF files, making manual extraction slow, error-prone, and difficult to scale across many documents and formats.",
+      "solution_approach": "The project converts invoice PDFs into images, applies Tesseract OCR, extracts key invoice fields using pattern matching, validates the extracted data, and exports structured results in JSON, CSV, or Excel formats.",
+      "results_or_impact": "Automates invoice processing workflows by producing structured, validated invoice outputs from raw PDF files. The project includes 95%+ test coverage and supports batch processing for multiple PDF invoices.",
+      "links": {
+        "github": "https://github.com/Saar-Sha/invoice-ocr-reader-portfolio",
+        "paper": null,
+        "demo": null
+      },
+      "featured": false,
+      "tags": [
+        "Python",
+        "OCR",
+        "Data Extraction",
+        "Automation",
+        "Invoices"
+      ]
     }
   ],
   "research": [


### PR DESCRIPTION
## Summary
Audited repositories under owner Saar-Sha and added all eligible portfolio-marked repositories missing from data/projects.json.

## Files modified
- data/projects.json

## Candidate repositories evaluated
- Saar-Sha/invoice-ocr-reader-portfolio
- Saar-Sha/Saar-Sha
- Saar-Sha/portfolio (host repository only)

## Portfolio marker results
- invoice-ocr-reader-portfolio: qualified (`<!-- PORTFOLIO: true -->` found)
- Saar-Sha: rejected (required exact marker missing)

## Docs used
- docs/ADD_NEW_PROJECT.md
- docs/PROJECT_STRUCTURE.md

## Validation results
- README exists for evaluated repositories.
- invoice-ocr-reader-portfolio includes valid portfolio marker and PORTFOLIO_METADATA block.
- No duplicate project id existed in data/projects.json.
- Only data/projects.json was modified.

## Missing information
- None.

## Manual verification steps
1. Review data/projects.json on this branch.
2. Confirm invoice-ocr-reader-portfolio appears under tools.
3. Open pages/projects.html locally and verify project rendering.

## Removed projects
- None.